### PR TITLE
Add flag to enable / disable logger

### DIFF
--- a/lib/core/catcher.dart
+++ b/lib/core/catcher.dart
@@ -32,11 +32,17 @@ class Catcher with ReportModeAction {
   Map<String, dynamic> _applicationParameters = Map();
   List<Report> _cachedReports = List();
   LocalizationOptions _localizationOptions;
+  bool enableLogger;
 
   static Catcher _instance;
 
-  Catcher(this.rootWidget,
-      {this.releaseConfig, this.debugConfig, this.profileConfig}) {
+  Catcher(
+    this.rootWidget, {
+    this.releaseConfig,
+    this.debugConfig,
+    this.profileConfig,
+    this.enableLogger = true,
+  }) {
     _configure();
   }
 
@@ -119,11 +125,13 @@ class Catcher with ReportModeAction {
   }
 
   void _configureLogger() {
-    Logger.root.level = Level.ALL;
-    Logger.root.onRecord.listen((LogRecord rec) {
-      print(
-          '[${rec.time} | ${rec.loggerName} | ${rec.level.name}] ${rec.message}');
-    });
+    if (enableLogger) {
+      Logger.root.level = Level.ALL;
+      Logger.root.onRecord.listen((LogRecord rec) {
+        print(
+            '[${rec.time} | ${rec.loggerName} | ${rec.level.name}] ${rec.message}');
+      });
+    }
   }
 
   _loadDeviceInfo() {


### PR DESCRIPTION
Hi @jhomlala,
I added a flag in the constructor of `Catcher` to disable the description to `onRecord` of `Logger`.

Reason being that when someone wants to use `Catcher` and already uses the `Logger` package with their own `onRecord` listener, every log message will be logged twice.

Feel free to close this PR if you think it's not necessary or if you plan to address this issue in a different way ;).