### PR TITLE
Fix email auto handler returns null

### DIFF
--- a/lib/handlers/email_auto_handler.dart
+++ b/lib/handlers/email_auto_handler.dart
@@ -1,5 +1,5 @@
-import 'package:catcher/model/report.dart';
 import 'package:catcher/handlers/report_handler.dart';
+import 'package:catcher/model/report.dart';
 import 'package:logging/logging.dart';
 import 'package:mailer/mailer.dart';
 import 'package:mailer/smtp_server.dart';
@@ -58,7 +58,7 @@ class EmailAutoHandler extends ReportHandler {
         if (sendReport.validationProblems != null &&
             sendReport.validationProblems.length > 0) {
           for (var problem in sendReport.validationProblems) {
-            _printLog("Problem: " + problem.code + " msg: " + problem.msg);
+            _printLog("Problem: ${problem?.code} msg: ${problem?.msg}");
           }
         }
         return sendReport.sent;


### PR DESCRIPTION
When using the `EmailAutoHandler` an exception is thrown in `catcher.dart` line 338 because `result` is `null`.

It is caused in the `EmailAutoHandler` by a `NoSuchMethodError` in `_sendMail` because `problem` is `null` when attempting to log it.


Also I am not sure what the point of the `SendReport` loop is in line 56 since its just returning the first result and only logging the problems of the first result but I just left it as it is.