### PR TITLE
Sentry improvements

### DIFF
--- a/lib/handlers/sentry_handler.dart
+++ b/lib/handlers/sentry_handler.dart
@@ -24,8 +24,7 @@ class SentryHandler extends ReportHandler {
   Future<bool> handle(Report error) async {
     try {
       _printLog("Logging to sentry...");
-      await sentryClient.captureException(
-          exception: error.error, stackTrace: error.stackTrace);
+
       var tags = Map<String, dynamic>();
       if (enableApplicationParameters) {
         tags.addAll(error.applicationParameters);
@@ -38,7 +37,11 @@ class SentryHandler extends ReportHandler {
       }
 
       var event = buildEvent(error, tags);
-      await sentryClient.capture(event: event);
+      final sentryResult = await sentryClient.capture(event: event);
+      
+      if (!sentryResult.isSuccessful) {
+        throw Exception(sentryResult.error);
+      }
       _printLog("Logged to sentry!");
       return true;
     } catch (exception) {


### PR DESCRIPTION
The current implementation of the Sentry handler logs 2 different events because both `captureException` and` capture` are being called, while `captureException` is basically a subtype of `capture`. 

Implementation of `captureException`:
```dart
  /// Reports the [exception] and optionally its [stackTrace] to Sentry.io.
  Future<SentryResponse> captureException({
    @required dynamic exception,
    dynamic stackTrace,
  }) {
    final Event event = Event(
      exception: exception,
      stackTrace: stackTrace,
    );
    return capture(event: event);
  }
```

Also a check to the `capture` response is added to fix #72 