### PR TITLE
Added ability to set user context for sentry handler

### DIFF
--- a/lib/handlers/sentry_handler.dart
+++ b/lib/handlers/sentry_handler.dart
@@ -6,6 +6,7 @@ import 'package:sentry/sentry.dart';
 
 class SentryHandler extends ReportHandler {
   final SentryClient sentryClient;
+  final User userContext;
   final bool enableDeviceParameters;
   final bool enableApplicationParameters;
   final bool enableCustomParameters;
@@ -13,7 +14,8 @@ class SentryHandler extends ReportHandler {
   final Logger _logger = Logger("SentryHandler");
 
   SentryHandler(this.sentryClient,
-      {this.enableDeviceParameters = true,
+      {this.userContext,
+      this.enableDeviceParameters = true,
       this.enableApplicationParameters = true,
       this.enableCustomParameters = true,
       this.printLogs = true})
@@ -83,6 +85,7 @@ class SentryHandler extends ReportHandler {
       level: SeverityLevel.error,
       culprit: "",
       tags: changeToSentryMap(tags),
+      userContext: this.userContext
     );
   }
 


### PR DESCRIPTION
Added the ability to set user context. This may be useful in the following cases:

- Linking user errors with analytics systems.
- Separation of errors by users.
- etc

To implement this function, the `User` class from the sentry library was used. The `userContext` parameter is optional and does not break backward compatibility.

How to use:
```dart
  final debugOptions = CatcherOptions(SilentReportMode(), [
    SentryHandler(SentryClient(dsn: 'your-dsn'), userContext: User(id: 'xxxx-xxxx-xxxx-xxxx')),
  ]);

```
More info in sentry docs:
https://docs.sentry.io/enriching-error-data/additional-data/?platform=javascript#capturing-the-user 
https://develop.sentry.dev/sdk/event-payloads/user/

