### PR TITLE
Update PageReportMode to pass correct context for app level theme.

### DIFF
--- a/lib/mode/page_report_mode.dart
+++ b/lib/mode/page_report_mode.dart
@@ -53,9 +53,11 @@ class PageWidget extends StatefulWidget {
 class PageWidgetState extends State<PageWidget> {
   @override
   Widget build(BuildContext context) {
-    return CatcherUtils.isCupertinoAppAncestor(context)
-        ? _buildCupertinoPage()
-        : _buildMaterialPage();
+    return Builder(
+      builder: (context) => CatcherUtils.isCupertinoAppAncestor(context)
+          ? _buildCupertinoPage()
+          : _buildMaterialPage(),
+    );
   }
 
   Widget _buildMaterialPage() {
@@ -82,8 +84,6 @@ class PageWidgetState extends State<PageWidget> {
 
   Widget _buildInnerWidget() {
     return Container(
-      padding: const EdgeInsets.symmetric(vertical: 10),
-      decoration: BoxDecoration(color: Colors.white),
       child: Column(
         children: [
           Padding(
@@ -101,9 +101,11 @@ class PageWidgetState extends State<PageWidget> {
           Padding(
             padding: const EdgeInsets.only(top: 20),
           ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: _getStackTraceWidget(),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: _getStackTraceWidget(),
+            ),
           ),
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
@@ -127,9 +129,9 @@ class PageWidgetState extends State<PageWidget> {
 
   TextStyle _getTextStyle(double fontSize) {
     return TextStyle(
-        fontSize: fontSize,
-        color: Colors.black,
-        decoration: TextDecoration.none);
+      fontSize: fontSize,
+      decoration: TextDecoration.none,
+    );
   }
 
   Widget _getStackTraceWidget() {


### PR DESCRIPTION
- Add Builder widget to PageReportMode to pass correct context for app level theme.
- Remove hard coded colors.
- Allow stack trace to expand with screen size instead of hard coded to fit in 40% of screen.