### PR TITLE
Add basic desktop  support for macOS/Windows

### DIFF
--- a/lib/core/application_profile_manager.dart
+++ b/lib/core/application_profile_manager.dart
@@ -28,4 +28,10 @@ class ApplicationProfileManager {
 
   /// Check if current platform is ios
   static bool isIos() => Platform.isIOS;
+
+  /// Check if current platform is ios
+  static bool isMacOS() => Platform.isMacOS;
+
+  /// Check if current platform is ios
+  static bool isWindows() => Platform.isWindows;
 }

--- a/lib/core/catcher.dart
+++ b/lib/core/catcher.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 import 'dart:isolate';
 
 import 'package:catcher/core/application_profile_manager.dart';
@@ -226,18 +225,16 @@ class Catcher with ReportModeAction {
   void _loadDeviceInfo() {
     if (ApplicationProfileManager.isWeb()) {
       _loadWebParameters();
+    } else if (ApplicationProfileManager.isAndroid()) {
+      DeviceInfoPlugin().androidInfo.then((androidInfo) {
+        _loadAndroidParameters(androidInfo);
+      });
+    } else if (ApplicationProfileManager.isIos()) {
+      DeviceInfoPlugin().iosInfo.then((iosInfo) {
+        _loadIosParameters(iosInfo);
+      });
     } else {
-      ///There is no device info web implementation
-      DeviceInfoPlugin deviceInfo = DeviceInfoPlugin();
-      if (Platform.isAndroid) {
-        deviceInfo.androidInfo.then((androidInfo) {
-          _loadAndroidParameters(androidInfo);
-        });
-      } else {
-        deviceInfo.iosInfo.then((iosInfo) {
-          _loadIosParameters(iosInfo);
-        });
-      }
+      // To be implemented
     }
   }
 
@@ -301,8 +298,9 @@ class Catcher with ReportModeAction {
     _applicationParameters["environment"] =
         describeEnum(ApplicationProfileManager.getApplicationProfile());
 
-    ///There is no package info web implementation
-    if (!ApplicationProfileManager.isWeb()) {
+    ///There is no package info web and windows implementation
+    if (!ApplicationProfileManager.isWeb() &&
+        !ApplicationProfileManager.isWindows()) {
       PackageInfo.fromPlatform().then((packageInfo) {
         _applicationParameters["version"] = packageInfo.version;
         _applicationParameters["appName"] = packageInfo.appName;
@@ -566,6 +564,12 @@ class Catcher with ReportModeAction {
     }
     if (ApplicationProfileManager.isIos()) {
       return PlatformType.iOS;
+    }
+    if (ApplicationProfileManager.isMacOS()) {
+      return PlatformType.MacOS;
+    }
+    if (ApplicationProfileManager.isWindows()) {
+      return PlatformType.Windows;
     }
     return PlatformType.Unknown;
   }

--- a/lib/core/catcher.dart
+++ b/lib/core/catcher.dart
@@ -298,9 +298,10 @@ class Catcher with ReportModeAction {
     _applicationParameters["environment"] =
         describeEnum(ApplicationProfileManager.getApplicationProfile());
 
-    ///There is no package info web and windows implementation
-    if (!ApplicationProfileManager.isWeb() &&
-        !ApplicationProfileManager.isWindows()) {
+    ///Only android, iOS and macOS are implemented
+    if (ApplicationProfileManager.isAndroid() ||
+        ApplicationProfileManager.isIos() ||
+        ApplicationProfileManager.isMacOS()) {
       PackageInfo.fromPlatform().then((packageInfo) {
         _applicationParameters["version"] = packageInfo.version;
         _applicationParameters["appName"] = packageInfo.appName;

--- a/lib/handlers/console_handler.dart
+++ b/lib/handlers/console_handler.dart
@@ -81,6 +81,11 @@ class ConsoleHandler extends ReportHandler {
   }
 
   @override
-  List<PlatformType> getSupportedPlatforms() =>
-      [PlatformType.Android, PlatformType.iOS, PlatformType.Web];
+  List<PlatformType> getSupportedPlatforms() => [
+        PlatformType.Android,
+        PlatformType.iOS,
+        PlatformType.Web,
+        PlatformType.MacOS,
+        PlatformType.Windows
+      ];
 }

--- a/lib/handlers/discord_handler.dart
+++ b/lib/handlers/discord_handler.dart
@@ -127,6 +127,11 @@ class DiscordHandler extends ReportHandler {
   }
 
   @override
-  List<PlatformType> getSupportedPlatforms() =>
-      [PlatformType.Web, PlatformType.Android, PlatformType.iOS];
+  List<PlatformType> getSupportedPlatforms() => [
+        PlatformType.Web,
+        PlatformType.Android,
+        PlatformType.iOS,
+        PlatformType.MacOS,
+        PlatformType.Windows
+      ];
 }

--- a/lib/handlers/email_auto_handler.dart
+++ b/lib/handlers/email_auto_handler.dart
@@ -189,6 +189,10 @@ class EmailAutoHandler extends ReportHandler {
   }
 
   @override
-  List<PlatformType> getSupportedPlatforms() =>
-      [PlatformType.Android, PlatformType.iOS];
+  List<PlatformType> getSupportedPlatforms() => [
+        PlatformType.Android,
+        PlatformType.iOS,
+        PlatformType.MacOS,
+        PlatformType.Windows
+      ];
 }

--- a/lib/handlers/file_handler.dart
+++ b/lib/handlers/file_handler.dart
@@ -149,6 +149,10 @@ class FileHandler extends ReportHandler {
   }
 
   @override
-  List<PlatformType> getSupportedPlatforms() =>
-      [PlatformType.Android, PlatformType.iOS];
+  List<PlatformType> getSupportedPlatforms() => [
+        PlatformType.Android,
+        PlatformType.iOS,
+        PlatformType.MacOS,
+        PlatformType.Windows
+      ];
 }

--- a/lib/handlers/http_handler.dart
+++ b/lib/handlers/http_handler.dart
@@ -102,6 +102,11 @@ class HttpHandler extends ReportHandler {
   }
 
   @override
-  List<PlatformType> getSupportedPlatforms() =>
-      [PlatformType.Web, PlatformType.Android, PlatformType.iOS];
+  List<PlatformType> getSupportedPlatforms() => [
+        PlatformType.Web,
+        PlatformType.Android,
+        PlatformType.iOS,
+        PlatformType.MacOS,
+        PlatformType.Windows
+      ];
 }

--- a/lib/handlers/sentry_handler.dart
+++ b/lib/handlers/sentry_handler.dart
@@ -128,6 +128,11 @@ class SentryHandler extends ReportHandler {
   }
 
   @override
-  List<PlatformType> getSupportedPlatforms() =>
-      [PlatformType.Web, PlatformType.Android, PlatformType.iOS];
+  List<PlatformType> getSupportedPlatforms() => [
+        PlatformType.Web,
+        PlatformType.Android,
+        PlatformType.iOS,
+        PlatformType.MacOS,
+        PlatformType.Windows
+      ];
 }

--- a/lib/handlers/slack_handler.dart
+++ b/lib/handlers/slack_handler.dart
@@ -106,6 +106,12 @@ class SlackHandler extends ReportHandler {
   }
 
   @override
-  List<PlatformType> getSupportedPlatforms() =>
-      [PlatformType.Android, PlatformType.iOS];
+  List<PlatformType> getSupportedPlatforms() => [
+        // should also support web since only use dio
+        PlatformType.Web,
+        PlatformType.Android,
+        PlatformType.iOS,
+        PlatformType.MacOS,
+        PlatformType.Windows
+      ];
 }

--- a/lib/mode/dialog_report_mode.dart
+++ b/lib/mode/dialog_report_mode.dart
@@ -75,6 +75,11 @@ class DialogReportMode extends ReportMode {
   }
 
   @override
-  List<PlatformType> getSupportedPlatforms() =>
-      [PlatformType.Web, PlatformType.Android, PlatformType.iOS];
+  List<PlatformType> getSupportedPlatforms() => [
+        PlatformType.Web,
+        PlatformType.Android,
+        PlatformType.iOS,
+        PlatformType.MacOS,
+        PlatformType.Windows
+      ];
 }

--- a/lib/mode/page_report_mode.dart
+++ b/lib/mode/page_report_mode.dart
@@ -4,7 +4,6 @@ import 'package:catcher/model/report_mode.dart';
 import 'package:catcher/utils/catcher_utils.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 class PageReportMode extends ReportMode {
   final bool showStackTrace;
@@ -34,8 +33,13 @@ class PageReportMode extends ReportMode {
   }
 
   @override
-  List<PlatformType> getSupportedPlatforms() =>
-      [PlatformType.Web, PlatformType.Android, PlatformType.iOS];
+  List<PlatformType> getSupportedPlatforms() => [
+        PlatformType.Web,
+        PlatformType.Android,
+        PlatformType.iOS,
+        PlatformType.MacOS,
+        PlatformType.Windows
+      ];
 }
 
 class PageWidget extends StatefulWidget {

--- a/lib/mode/silent_report_mode.dart
+++ b/lib/mode/silent_report_mode.dart
@@ -11,6 +11,11 @@ class SilentReportMode extends ReportMode {
   }
 
   @override
-  List<PlatformType> getSupportedPlatforms() =>
-      [PlatformType.Web, PlatformType.Android, PlatformType.iOS];
+  List<PlatformType> getSupportedPlatforms() => [
+        PlatformType.Web,
+        PlatformType.Android,
+        PlatformType.iOS,
+        PlatformType.MacOS,
+        PlatformType.Windows
+      ];
 }

--- a/lib/model/platform_type.dart
+++ b/lib/model/platform_type.dart
@@ -1,1 +1,1 @@
-enum PlatformType { Android, iOS, Web, Unknown }
+enum PlatformType { Android, iOS, Web, MacOS, Windows, Unknown }


### PR DESCRIPTION
Currently, `catcher` package only support Android, iOS and web. However, most functions should be compatible for desktop and easy to implement. 

**Compatible handlers:**
- `ConsoleHandler`: it only depends on `logging` which is a pure dart package and `catcher` handle message by `print` only. **Even it should support** `PlatformType.Unknown`.
- `FileHandler`: `io` module should support all desktops.
- `HttpHandler`, `SentryHandler`, `SlackHandler`, `DiscardHandler`, `EmailAutoHandler`:
    - these depend on `dio` and `mailer`, which also support http connections for desktops. 

For above changes, it should also be compatible with Linux, but I don't have a flutter-linux environment to test. But it should be supported. If you could test linux, please add linux support later.

**Compatible report modes:**
- currently, all report modes are pure material/cupertino widgets. **Even it should support** `PlatformType.Unknown`.

**Incompatible:**
- `EmailManualHandler`: `flutter_mailer` doesn't support desktop yet. Alternative solution not found.
- `ToastHandler`: `fluttertoast` doesn't support desktop. Other alternative like `flutter_easyloding`, `bot_toast` are support all platforms since they are pure flutter packages.
- `device_info`: only support android and ios, so let's skip it if it's not supported. (It was using `if android else ios`, which will raise error in desktop)
- `package info`: only android, ios and macOS. It's better to check **is some platform** rather **is not some platform**