### PR TITLE
Update Sentry and Mailer to 5.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,11 +16,11 @@ dependencies:
   fluttertoast: ^8.0.1-nullsafety.0
   device_info_plus: ^1.0.0
   package_info: ^2.0.0
-  mailer: ^4.0.0
+  mailer: ^5.0.0
   dio: ^4.0.0-beta6
   flutter_mailer: ^2.0.0-null-safe
   logging: ^1.0.0
-  sentry: ^4.1.0-nullsafety.1
+  sentry: ^5.0.0
   universal_io: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
The stable sound null-safe versions have been released now and thus an upgrade would be best

Closes #167 