### PR TITLE
Enable async runAppFunction callbacks

### DIFF
--- a/lib/core/catcher.dart
+++ b/lib/core/catcher.dart
@@ -27,7 +27,7 @@ class Catcher with ReportModeAction {
   final Widget? rootWidget;
 
   ///Run app function which will be ran
-  final void Function()? runAppFunction;
+  final FutureOr<void> Function()? runAppFunction;
 
   /// Instance of catcher config used in release mode
   CatcherOptions? releaseConfig;
@@ -206,20 +206,18 @@ class Catcher with ReportModeAction {
         runApp(rootWidget!);
       });
     } else if (runAppFunction != null) {
-      _runZonedGuarded(() {
-        runAppFunction!();
-      });
+      _runZonedGuarded(runAppFunction!);
     } else {
       throw ArgumentError("Provide rootWidget or runAppFunction to Catcher.");
     }
   }
 
-  void _runZonedGuarded(void Function() callback) {
+  void _runZonedGuarded(FutureOr<void> Function() callback) {
     runZonedGuarded<Future<void>>(() async {
       if (ensureInitialized) {
         WidgetsFlutterBinding.ensureInitialized();
       }
-      callback();
+      await callback();
     }, (dynamic error, StackTrace stackTrace) {
       _reportError(error, stackTrace);
     });


### PR DESCRIPTION
Use `FutureOr<void>` for `runAppFunction` and `_runZonedGuarded` callback return type,
and pass `runAppFunction!` directly to `_runZonedGuarded`.

It seems that currently passing an async function to `runAppFunction` results in some error state, likely due to not being awaited. I'm not if there are any setup actions that _need_ to be in the same zone but it is more intuitive to add this flexibility if possible.

I made this patch directly in the GitHub UI so I may have missed something.