### PR TITLE
Fixing sending correct stacktrace on SentryHandler

### DIFF
--- a/lib/handlers/sentry_handler.dart
+++ b/lib/handlers/sentry_handler.dart
@@ -57,7 +57,7 @@ class SentryHandler extends ReportHandler {
       }
 
       final event = buildEvent(error, tags);
-      await sentryClient.captureEvent(event);
+      await sentryClient.captureEvent(event, stackTrace: error.stackTrace);
 
       _printLog("Logged to sentry!");
       return true;


### PR DESCRIPTION
The errors in Sentry where missing the correct stacktrace when reporting an error with Catcher.reportCheckedError(...). This fix adds the correct stacktrace to sentryClient.captureEvent(...) so the error can be found and debugged quicker.