### PR TITLE
fluttertoast version update

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  fluttertoast: ^8.0.8
+  fluttertoast: '>=8.2.2 <10.0.0'
   device_info_plus: ^7.0.0
   device_info_plus_platform_interface: ^6.0.0
   package_info_plus: ^3.0.0


### PR DESCRIPTION
Problem correction: https://github.com/jhomlala/catcher/issues/258

```
The Android Gradle plugin supports only Kotlin Gradle plugin version 1.5.20 and higher.
The following dependencies do not satisfy the required version:
project ':fluttertoast' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50
```