### PR TITLE
[Urgent] Update dependencies. (#296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.8.1
+* Updated dependencies version.
+
 ## 0.8.0
 * [BREAKING_CHANGE] Updated min android version to 22 and target/compile version to 34.
 * Updated dependencies version.

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,0 +1,44 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '12.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter application.
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -25,19 +25,18 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  path_provider: ^2.0.1
-  path_provider_macos: ^2.0.0
+  path_provider: ^2.1.2
+  path_provider_foundation: ^2.3.2
   dio: ^5.3.3
   permission_handler: ^11.0.1
-  flutter_local_notifications: ^16.1.0
-  sentry: ^7.12.0
+  flutter_local_notifications: ^17.0.0
+  sentry: ^7.18.0
   catcher:
     path: ../
 
-
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.6
 
 dev_dependencies:
   flutter_test:
@@ -48,7 +47,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: catcher
 description: Plugin for error catching which provides multiple handlers for dealing with errors when they are not caught by the developer.
-version: 0.8.0
+version: 0.8.1
 #author: Jakub Homlala <jhomlala@gmail.com>
 homepage: https://github.com/jhomlala/catcher
 repository: https://github.com/jhomlala/catcher
@@ -13,7 +13,7 @@ topics:
   - tool
 
 environment:
-  sdk: '>=2.19.6 <4.0.0'
+  sdk: ">=2.19.6 <4.0.0"
   flutter: ">=3.0.0"
 
 dependencies:
@@ -21,16 +21,16 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  fluttertoast: ^8.2.3
-  device_info_plus: ^9.1.0
+  fluttertoast: ^8.2.4
+  device_info_plus: ^10.0.0
   device_info_plus_platform_interface: ^7.0.0
-  package_info_plus: ^4.2.0
-  mailer: ^6.0.1
-  dio: ^5.3.3
-  flutter_mailer: ^2.0.0
-  logging: ^1.0.2
-  sentry: ^7.12.0
-  universal_io: ^2.0.4
+  package_info_plus: ^6.0.0
+  mailer: ^6.1.0
+  dio: ^5.4.1
+  flutter_mailer: ^2.1.2
+  logging: ^1.2.0
+  sentry: ^7.18.0
+  universal_io: ^2.2.2
   very_good_analysis: ^5.1.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   fluttertoast: ^8.2.4
-  device_info_plus: ^10.0.0
+  device_info_plus: ^10.0.1
   device_info_plus_platform_interface: ^7.0.0
   package_info_plus: ^6.0.0
   mailer: ^6.1.0


### PR DESCRIPTION
The following issues are now supported
https://github.com/jhomlala/catcher/issues/269

The device_info_plus and package_info_plus on which this plugin depends provide the latest versions. Updates to these dependent packages include compliance with Apple's privacy policy.
This means that if you do not comply with this, your app will soon not be able to pass Apple's review process.
This will affect many users and needs to be addressed immediately.

